### PR TITLE
move backend keys to service specific json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-apikeys.js
+keys.json
 /front/src/apikey.js
 

--- a/back/gerenciamento-aglomeracoes/server.js
+++ b/back/gerenciamento-aglomeracoes/server.js
@@ -1,11 +1,13 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const keys = require('./../../apikeys.js');
+const fs = require('fs')
 const app = express();
 const { MongoClient } = require("mongodb");
 var ObjectId = require('mongodb').ObjectId
 
 app.use(bodyParser.urlencoded({extended: true}))
+
+var keys = JSON.parse(fs.readFileSync('./keys.json'))
 
 app.listen(3000,function() {
     console.log('listening on 3000')


### PR DESCRIPTION
Moves backend keys to service-specific file.
It does not make sense to share a key file across multiple services since they are supposed to be independent ....

https://github.com/leosole/aglomerados/issues/27